### PR TITLE
Add AFTEREFFECTS_ADAPTOR_AERENDER_EXE env var

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,8 @@
+## How can I override the path to the AERender executable?
+
+There is a feature within the AfterEffects Deadline Cloud package that allows you the ability to
+set the `AFTEREFFECTS_ADAPTOR_AERENDER_EXE` environment variable and point to the after effects
+aerender executable directly.
+
+The recommended route is still to ensure that aerender is in your system path, however some clients
+have found it easier to set an environment variable directly instead.

--- a/src/deadline/ae_adaptor/AEClient/ae_handler.py
+++ b/src/deadline/ae_adaptor/AEClient/ae_handler.py
@@ -63,10 +63,11 @@ class AEHandler:
 
         filename = self.output_pattern + "." + self.output_format
         output = os.path.join(self.output_dir, filename)
+        ae_render_exe = os.environ.get("AFTEREFFECTS_ADAPTOR_AERENDER_EXECUTABLE", "aerender")
 
         subprocess.run(
             [
-                "aerender",
+                ae_render_exe,
                 "-project",
                 self.file_path,
                 "-comp",


### PR DESCRIPTION
This environment variable allows overriding the path to the `aerender` executable.

### What was the problem/requirement? (What/Why)

### What was the solution? (How)

### What is the impact of this change?

### How was this change tested?

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```

### Was this change documented?

### Is this a breaking change?

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
